### PR TITLE
fix(frontend): Remove unused function to fix build error

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -40,15 +40,6 @@ function App() {
   const hitCanvasRef = useRef(null);
 
   // --- Canvas & Data Handlers ---
-  const clearCanvases = () => {
-    [originalCanvasRef, segmentedCanvasRef, hitCanvasRef].forEach(ref => {
-      if (ref.current) {
-        const ctx = ref.current.getContext('2d');
-        ctx.clearRect(0, 0, ref.current.width, ref.current.height);
-      }
-    });
-  };
-
   const handleProjectSelect = (project) => {
     setSelectedProject(project);
     setSelectedSample(null);


### PR DESCRIPTION
Removes the `clearCanvases` function from `App.js`. This function was made obsolete by later refactoring but was not removed.

The `create-react-app` production build script treats unused functions as a fatal error, which was causing the deployment to fail with exit code 1. Removing this dead code resolves the build failure.