### PR TITLE
fix(frontend): Replace call to non-existent function in draw effect

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -169,7 +169,13 @@ function App() {
     const contoursToDraw = isEditing ? localContours : selectedSample?.results?.contours;
 
     if (!selectedSample || !contoursToDraw) {
-      clearCanvases();
+      // Manually clear canvases if there's nothing to draw
+      [originalCanvasRef, segmentedCanvasRef, hitCanvasRef].forEach(ref => {
+        if (ref.current) {
+          const ctx = ref.current.getContext('2d');
+          ctx.clearRect(0, 0, ref.current.width, ref.current.height);
+        }
+      });
       return;
     }
 


### PR DESCRIPTION
This commit fixes a critical bug that caused the `npm run build` process to fail. A previous refactoring removed the `clearCanvases` function, but a call to this function remained inside the `draw` effect.

This has been corrected by replacing the erroneous function call with the correct in-line logic for clearing the canvases. This resolves the fatal error and should allow the frontend to build successfully.