### PR TITLE
fix(frontend): Add useCallback and fix useEffect dependencies

### DIFF
--- a/frontend/src/components/ProjectList.js
+++ b/frontend/src/components/ProjectList.js
@@ -1,21 +1,17 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useCallback } from 'react';
 import axios from 'axios';
 import './ProjectList.css';
 
 const API_URL = 'http://localhost:5000/api';
 
-function ProjectList({ onProjectSelect }) {
+function ProjectList({ onProjectSelect, selectedProject }) {
   const [projects, setProjects] = useState([]);
   const [newProjectName, setNewProjectName] = useState('');
   const [newProjectDesc, setNewProjectDesc] = useState('');
   const [error, setError] = useState('');
   const [loading, setLoading] = useState(true);
 
-  useEffect(() => {
-    fetchProjects();
-  }, []);
-
-  const fetchProjects = async () => {
+  const fetchProjects = useCallback(async () => {
     try {
       setLoading(true);
       const response = await axios.get(`${API_URL}/projects`);
@@ -27,7 +23,11 @@ function ProjectList({ onProjectSelect }) {
     } finally {
       setLoading(false);
     }
-  };
+  }, []);
+
+  useEffect(() => {
+    fetchProjects();
+  }, [fetchProjects]);
 
   const handleCreateProject = async (e) => {
     e.preventDefault();

--- a/frontend/src/components/SampleList.js
+++ b/frontend/src/components/SampleList.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useCallback } from 'react';
 import axios from 'axios';
 import './SampleList.css';
 
@@ -9,22 +9,8 @@ function SampleList({ project, onSampleSelect, newSample, selectedSample }) {
   const [error, setError] = useState('');
   const [loading, setLoading] = useState(true);
 
-  useEffect(() => {
-    if (project) {
-      fetchSamples();
-    } else {
-      setSamples([]);
-    }
-  }, [project]);
-
-  useEffect(() => {
-    // Add the new sample to the top of the list when it's created
-    if (newSample && !samples.find(s => s.id === newSample.id)) {
-      setSamples([newSample, ...samples]);
-    }
-  }, [newSample]);
-
-  const fetchSamples = async () => {
+  const fetchSamples = useCallback(async () => {
+    if (!project) return;
     try {
       setLoading(true);
       const response = await axios.get(`${API_URL}/projects/${project.id}/samples`);
@@ -36,7 +22,18 @@ function SampleList({ project, onSampleSelect, newSample, selectedSample }) {
     } finally {
       setLoading(false);
     }
-  };
+  }, [project]);
+
+  useEffect(() => {
+    fetchSamples();
+  }, [fetchSamples]);
+
+  useEffect(() => {
+    // Add the new sample to the top of the list when it's created
+    if (newSample && !samples.find(s => s.id === newSample.id)) {
+      setSamples([newSample, ...samples]);
+    }
+  }, [newSample, samples]);
 
   const handleDeleteSample = async (e, id) => {
     e.stopPropagation(); // Prevent the li's onClick from firing


### PR DESCRIPTION
This commit fixes a recurring build error by refactoring components to correctly handle dependencies in `useEffect` hooks.

- Wraps data-fetching functions in `ProjectList` and `SampleList` with `useCallback`.
- Adds the memoized functions to the `useEffect` dependency arrays.

This prevents functions from being redefined on every render, which avoids infinite loops and satisfies the strict linting rules of the `react-scripts build` process. This is a common cause of build failures in CI/CD environments.