### PR TITLE
feat: Rename application to Metallographic Analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Metallobox Web
+# Metallographic Analysis
 
-A modern, web-based clone of the Metallobox software for metallographic image analysis, built with React, Flask, and OpenCV, and deployed with Docker.
+A modern, web-based application for metallographic image analysis, built with React, Flask, and OpenCV, and deployed with Docker.
 
 ## Tech Stack
 

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>Metallobox Web</title>
+    <title>Metallographic Analysis</title>
     <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
   </head>
   <body>

--- a/frontend/public/manifest.json
+++ b/frontend/public/manifest.json
@@ -1,6 +1,6 @@
 {
-  "short_name": "Metallobox",
-  "name": "Metallobox Web",
+  "short_name": "Met-Analysis",
+  "name": "Metallographic Analysis",
   "start_url": ".",
   "display": "standalone",
   "theme_color": "#000000",

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -218,7 +218,7 @@ function App() {
 
   return (
     <div className="App">
-      <header className="App-header"><h1>Metallobox Clone</h1></header>
+      <header className="App-header"><h1>Metallographic Analysis</h1></header>
       <main>
         <div className="main-layout">
           <div className="project-sidebar">


### PR DESCRIPTION
This commit updates the application name from 'Metallobox Clone' to 'Metallographic Analysis' as requested by you.

The name has been changed in the following files:
- README.md
- frontend/public/index.html
- frontend/public/manifest.json
- frontend/src/App.js