### PR TITLE
fix(backend): Implement strict and correct CORS policy

### DIFF
--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -5,8 +5,8 @@ import os
 
 def create_app():
     app = Flask(__name__)
-    # Use a simpler, global CORS configuration for debugging
-    CORS(app)
+    # Use a very permissive CORS configuration to ensure browser communication
+    CORS(app, resources={r"/api/*": {"origins": "http://localhost:8080"}}, supports_credentials=True)
 
     # Configure database
     app.config['SQLALCHEMY_DATABASE_URI'] = os.environ.get('DATABASE_URL', 'sqlite:////data/metallobox.db')


### PR DESCRIPTION
This commit resolves the final deployment issue where the frontend could not communicate with the backend due to browser CORS security policies.

While previous configurations were intended to be permissive, they were not explicit enough. This commit updates the Flask-CORS setup to:
- Specifically target routes under `/api/*`.
- Explicitly allow the frontend origin (`http://localhost:8080`).
- Support credentials, which is often required for cross-origin requests.

This is the standard and correct way to configure CORS for this type of application and should resolve the "Failed to fetch" error seen in the browser.