### PR TITLE
fix(frontend): Correct API URL for frontend-backend communication

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,9 @@
 services:
   frontend:
-    build: ./frontend
+    build:
+      context: ./frontend
+      args:
+        - REACT_APP_API_URL=http://localhost:5000/api
     ports:
       - "8080:80"
 

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,5 +1,6 @@
 # --- Build Stage ---
 FROM node:18-alpine AS build
+ARG REACT_APP_API_URL
 WORKDIR /app
 
 COPY package.json ./
@@ -8,6 +9,7 @@ COPY package.json ./
 RUN npm install
 
 COPY . .
+ENV REACT_APP_API_URL=$REACT_APP_API_URL
 RUN npm run build
 
 # --- Production Stage ---

--- a/frontend/src/components/ProjectList.js
+++ b/frontend/src/components/ProjectList.js
@@ -2,7 +2,7 @@ import React, { useState, useEffect, useCallback } from 'react';
 import axios from 'axios';
 import './ProjectList.css';
 
-const API_URL = 'http://backend:5000/api';
+const API_URL = process.env.REACT_APP_API_URL || 'http://localhost:5000/api';
 
 function ProjectList({ onProjectSelect, selectedProject }) {
   const [projects, setProjects] = useState([]);


### PR DESCRIPTION
The frontend was unable to communicate with the backend because it was using a hardcoded, internal Docker hostname ('http://backend:5000') for API calls. This address is not resolvable from your browser.

This commit fixes the issue by:
- Modifying the frontend React code to use a `REACT_APP_API_URL` environment variable.
- Updating the Dockerfile to accept this variable as a build argument.
- Configuring docker-compose.yml to pass the correct public-facing URL (`http://localhost:5000/api`) to the frontend build process.

This ensures the compiled frontend code calls the correct, browser-accessible API endpoint.