### PR TITLE
feat: Configure application for external access

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,4 @@ A modern, web-based application for metallographic image analysis, built with Re
     ```bash
     docker-compose up --build
     ```
-2.  Once the containers are running, access the application:
-    -   **Frontend:** `http://localhost:8080`
-    -   **Backend API:** `http://localhost:5000`
+2.  Once the containers are running, access the application by navigating to `http://<your-server-ip>:8080` in your web browser. If you are running it on your local machine, you can use `http://localhost:8080`.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,9 +1,6 @@
 services:
   frontend:
-    build:
-      context: ./frontend
-      args:
-        - REACT_APP_API_URL=http://localhost:5000/api
+    build: ./frontend
     ports:
       - "8080:80"
 

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,6 +1,5 @@
 # --- Build Stage ---
 FROM node:18-alpine AS build
-ARG REACT_APP_API_URL
 WORKDIR /app
 
 COPY package.json ./
@@ -9,11 +8,11 @@ COPY package.json ./
 RUN npm install
 
 COPY . .
-ENV REACT_APP_API_URL=$REACT_APP_API_URL
 RUN npm run build
 
 # --- Production Stage ---
 FROM nginx:1.23-alpine
+COPY nginx.conf /etc/nginx/conf.d/default.conf
 WORKDIR /usr/share/nginx/html
 RUN rm -rf ./*
 COPY --from=build /app/build .

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -1,0 +1,27 @@
+server {
+    listen 80;
+    server_name localhost;
+
+    root /usr/share/nginx/html;
+    index index.html;
+
+    location / {
+        try_files $uri /index.html;
+    }
+
+    location /api/ {
+        proxy_pass http://backend:5000;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    location /uploads/ {
+        proxy_pass http://backend:5000;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+}

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -10,7 +10,7 @@ import EditorToolbar from './components/EditorToolbar';
 import HistogramChart from './components/HistogramChart';
 import MultiphaseAnalysis from './components/MultiphaseAnalysis';
 
-const API_URL = process.env.REACT_APP_API_URL || "http://localhost:5000/api";
+const API_URL = "/api";
 
 const generateColor = (index) => {
   const r = (index * 30) % 255;

--- a/frontend/src/components/AddSampleForm.js
+++ b/frontend/src/components/AddSampleForm.js
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import axios from 'axios';
 import './AddSampleForm.css';
 
-const API_URL = process.env.REACT_APP_API_URL || "http://localhost:5000/api";
+const API_URL = "/api";
 
 function AddSampleForm({ project, onSampleAdded }) {
   const [sampleName, setSampleName] = useState('');

--- a/frontend/src/components/Calibration.js
+++ b/frontend/src/components/Calibration.js
@@ -2,7 +2,7 @@ import React, { useState, useEffect, useRef } from 'react';
 import axios from 'axios';
 import './Calibration.css';
 
-const API_URL = process.env.REACT_APP_API_URL || "http://localhost:5000/api";
+const API_URL = "/api";
 
 function Calibration({ sample, onCalibrationUpdate, originalCanvas }) {
   const [isCalibrating, setIsCalibrating] = useState(false);

--- a/frontend/src/components/ProjectList.js
+++ b/frontend/src/components/ProjectList.js
@@ -2,7 +2,7 @@ import React, { useState, useEffect, useCallback } from 'react';
 import axios from 'axios';
 import './ProjectList.css';
 
-const API_URL = process.env.REACT_APP_API_URL || 'http://localhost:5000/api';
+const API_URL = '/api';
 
 function ProjectList({ onProjectSelect, selectedProject }) {
   const [projects, setProjects] = useState([]);

--- a/frontend/src/components/SampleList.js
+++ b/frontend/src/components/SampleList.js
@@ -2,7 +2,7 @@ import React, { useState, useEffect, useCallback } from 'react';
 import axios from 'axios';
 import './SampleList.css';
 
-const API_URL = process.env.REACT_APP_API_URL || "http://localhost:5000/api";
+const API_URL = "/api";
 
 function SampleList({ project, onSampleSelect, newSample, selectedSample }) {
   const [samples, setSamples] = useState([]);


### PR DESCRIPTION
This commit refactors the application's network configuration to allow it to be accessed from external IP addresses, not just localhost.

The key changes are:
- The frontend now uses a relative URL (/api) to communicate with the backend, removing the hardcoded 'localhost' URL.
- An nginx reverse proxy is configured to serve the frontend and route all API requests to the backend service. This is handled within the Docker network.
- The Docker configurations (Dockerfile and docker-compose.yml) have been updated to remove the now-unnecessary build-time API URL argument and to incorporate the nginx proxy configuration.
- The README has been updated to reflect the new access method.