### PR TITLE
I've added a new feature allowing you to directly input the image sca…

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -29,6 +29,7 @@ function App() {
   const [isEditing, setIsEditing] = useState(false);
   const [activeTool, setActiveTool] = useState('delete');
   const [localContours, setLocalContours] = useState([]);
+  const [canvasSize, setCanvasSize] = useState({ width: 0, height: 0 });
 
   const originalCanvasRef = useRef(null);
   const segmentedCanvasRef = useRef(null);
@@ -160,6 +161,7 @@ function App() {
           ctx.clearRect(0, 0, ref.current.width, ref.current.height);
         }
       });
+      setCanvasSize({ width: 0, height: 0 });
       return;
     }
 
@@ -176,6 +178,7 @@ function App() {
       [originalCanvas, segmentedCanvas, hitCanvas].forEach(c => {
         if(c) { c.width = img.width; c.height = img.height; }
       });
+      setCanvasSize({ width: img.width, height: img.height });
       originalCtx.drawImage(img, 0, 0);
       segmentedCtx.fillStyle = 'black';
       segmentedCtx.fillRect(0, 0, segmentedCanvas.width, segmentedCanvas.height);
@@ -237,7 +240,7 @@ function App() {
                     <>
                       {!isEditing ? (
                         <div className="controls-bar">
-                          <Calibration sample={selectedSample} onCalibrationUpdate={handleCalibrationUpdate} originalCanvas={originalCanvasRef.current}/>
+                          <Calibration sample={selectedSample} onCalibrationUpdate={handleCalibrationUpdate} originalCanvas={originalCanvasRef.current} canvasSize={canvasSize} />
                           <div className="measure-control">
                             <button onClick={handleMeasure} disabled={!selectedSample.scale_pixels_per_mm || isLoading}>
                               {isLoading ? 'Calculating...' : 'Calculate Measurements'}

--- a/frontend/src/components/Calibration.css
+++ b/frontend/src/components/Calibration.css
@@ -31,3 +31,22 @@
     color: #dc3545;
     font-size: 0.9em;
 }
+
+.direct-scale-input {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    margin-top: 4px;
+}
+
+.direct-scale-input input {
+    width: 100px;
+    padding: 8px;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+}
+
+.direct-scale-input span {
+    font-size: 0.9em;
+    color: #555;
+}


### PR DESCRIPTION
…le in microns per pixel. I also fixed a critical bug that prevented the visual calibration tool from working correctly.

**New Feature:**
- I added a new input field and a "Set" button to the calibration component.
- You can now enter a known scale (e.g., 0.563 µm/pixel) and save it directly, bypassing the visual two-click method.
- The component handles the necessary unit conversion from microns/pixel to the pixels/mm value required by the backend.

**Bug Fix:**
- I found that the visual calibration tool was failing because its overlay canvas did not resize when the main image was loaded.
- I fixed this by introducing a `canvasSize` state in the parent `App` component, which is passed down as a prop to the `Calibration` component.
- The `Calibration` component now uses this prop to correctly size its overlay, ensuring it appears correctly and is interactive.