### PR TITLE
fix: Make calibration overlay transparent

### DIFF
--- a/frontend/src/components/Calibration.css
+++ b/frontend/src/components/Calibration.css
@@ -25,6 +25,7 @@
     z-index: 10;
     cursor: crosshair;
     pointer-events: auto;
+    background-color: transparent;
 }
 
 .calibration-container .error-message {


### PR DESCRIPTION
This commit fixes a bug where the visual calibration overlay was appearing as a gray rectangle, obscuring the image underneath.

The overlay canvas was inheriting a generic `background-color: #f0f0f0;` style intended for all canvases in the application.

This change adds a specific CSS rule (`background-color: transparent;`) to the `.calibration-overlay` class, ensuring it is see-through and allowing you to see the original image while calibrating.