### PR TITLE
Fix: Update WeasyPrint dependencies in Dockerfile



### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,13 +1,20 @@
 FROM python:3.10
 
 # Install system dependencies for WeasyPrint and other libraries
+# Using the official list from WeasyPrint documentation for Debian/Ubuntu
 RUN apt-get update && apt-get install -y \
     build-essential \
     python3-dev \
-    libpango-1.0-0 \
-    libharfbuzz0b \
-    libffi-dev \
+    python3-pip \
+    python3-setuptools \
+    python3-wheel \
+    python3-cffi \
     libcairo2 \
+    libpango-1.0-0 \
+    libpangocairo-1.0-0 \
+    libgdk-pixbuf2.0-0 \
+    libffi-dev \
+    shared-mime-info \
     --no-install-recommends
 
 WORKDIR /app


### PR DESCRIPTION
This commit updates the system-level dependencies installed in the `backend/Dockerfile` to match the official list required by the `WeasyPrint` library on Debian-based systems.

The previous build failed because the `apt-get install` command could not find one of the specified packages. This change replaces the incorrect list with a comprehensive and verified list from the WeasyPrint documentation.

This should resolve the `exit code: 100` error during the backend service build process.