### PR TITLE
fix: Add .dockerignore to frontend to ensure clean builds

### DIFF
--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -1,0 +1,6 @@
+node_modules
+build
+.env
+npm-debug.log
+yarn-debug.log
+yarn-error.log


### PR DESCRIPTION
Adds a .dockerignore file to the frontend service to prevent local development artifacts, particularly the node_modules directory, from being copied into the Docker build context.

This change ensures that the `npm install` command runs in a clean environment within the container, which resolves build failures caused by `react-scripts: not found` errors due to environment inconsistencies.