### PR TITLE
I'm adding a debugging step to the frontend Dockerfile to check the c…

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -7,6 +7,9 @@ COPY package.json ./
 # COPY package-lock.json ./
 RUN npm install
 
+# Debugging step to check for react-scripts
+RUN ls -l /app/node_modules/.bin
+
 COPY . .
 RUN npm run build
 


### PR DESCRIPTION
…ontents of the `node_modules/.bin` directory after dependencies are installed. This will help me verify that the `react-scripts` executable is present and correctly linked, which should aid in diagnosing the 'react-scripts: not found' error.