### PR TITLE
I've introduced two new methods for grain size analysis based on the …

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -10,3 +10,5 @@ openpyxl
 SQLAlchemy
 shapely
 gunicorn
+matplotlib
+scipy

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -55,6 +55,15 @@ main {
 .sample-sidebar h3 {
   margin-top: 0;
 }
+
+.intercept-controls {
+  padding: 10px;
+  background-color: #f0f0f0;
+  border-bottom: 1px solid #ddd;
+  display: flex;
+  align-items: center;
+  gap: 15px;
+}
 .canvas-area {
   overflow-y: auto;
   padding: 20px;

--- a/frontend/src/components/ASTMChart.css
+++ b/frontend/src/components/ASTMChart.css
@@ -1,0 +1,27 @@
+.astm-chart-container {
+    margin-top: 20px;
+    padding: 15px;
+    border: 1px solid #ddd;
+    border-radius: 4px;
+}
+
+.chart-controls {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    margin-bottom: 15px;
+}
+
+.chart-controls label {
+    font-weight: bold;
+}
+
+.chart-controls input {
+    width: 80px;
+}
+
+.chart-display img {
+    max-width: 100%;
+    height: auto;
+    border: 1px solid #ccc;
+}

--- a/frontend/src/components/ASTMChart.js
+++ b/frontend/src/components/ASTMChart.js
@@ -1,0 +1,55 @@
+import React, { useState } from 'react';
+import axios from 'axios';
+import './ASTMChart.css';
+
+const API_URL = "/api";
+
+function ASTMChart({ sample, isLoading, setIsLoading, setError }) {
+  const [chart, setChart] = useState(null);
+  const [magnification, setMagnification] = useState(100);
+
+  const handleGenerateChart = async () => {
+    if (!sample) return;
+    setIsLoading(true);
+    setError('');
+    setChart(null);
+    try {
+      const response = await axios.post(`${API_URL}/api/samples/${sample.id}/astm-chart`,
+        { magnification },
+        { responseType: 'blob' }
+      );
+      const imageUrl = URL.createObjectURL(response.data);
+      setChart(imageUrl);
+    } catch (err) {
+      setError(err.response?.data?.error || 'Failed to generate ASTM chart.');
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <div className="astm-chart-container">
+      <h4>ASTM E112 Comparison Chart</h4>
+      <div className="chart-controls">
+        <label htmlFor="magnification">Magnification:</label>
+        <input
+          type="number"
+          id="magnification"
+          value={magnification}
+          onChange={(e) => setMagnification(e.target.value)}
+          disabled={isLoading}
+        />
+        <button onClick={handleGenerateChart} disabled={isLoading || !sample}>
+          {isLoading ? 'Generating...' : 'Generate Chart'}
+        </button>
+      </div>
+      {chart && (
+        <div className="chart-display">
+          <img src={chart} alt="ASTM E112 Comparison Chart" />
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default ASTMChart;

--- a/frontend/src/components/EditorToolbar.js
+++ b/frontend/src/components/EditorToolbar.js
@@ -19,6 +19,12 @@ function EditorToolbar({ activeTool, onToolSelect, onSave, onCancel, isSaving })
         >
           Split Grain
         </button>
+        <button
+          onClick={() => onToolSelect('line')}
+          className={activeTool === 'line' ? 'active' : ''}
+        >
+          Draw Line
+        </button>
       </div>
       <div className="actions">
         <button onClick={onSave} className="save-btn" disabled={isSaving}>


### PR DESCRIPTION
…ASTM E112 standard, enhancing the metallurgical analysis capabilities of your application.

Features added:
1.  ASTM E112 Intercept Method:
    - You can now draw lines on the segmented image in edit mode.
    - A prompt will ask you for the number of grain boundary intercepts for each line.
    - A new backend endpoint calculates the ASTM grain size number (G) using the intercept data and the image's scale.
    - The result is displayed in the UI.

2.  ASTM E112 Comparison Chart Method:
    - A new feature allows you to generate standard visual comparison charts for various ASTM G-numbers.
    - The charts are generated dynamically on the backend using Matplotlib and Voronoi diagrams to adapt to any magnification you specify.
    - A new frontend component provides an interface to generate and display these charts.