### PR TITLE
This commit fixes a JavaScript syntax error in the `handleAstmCalcula…

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -162,7 +162,7 @@ function App() {
     try {
       const response = await axios.post(`${API_URL}/api/samples/${selectedSample.id}/astm-e112`, { magnification });
       setSelectedSample(response.data);
-    } catch (err)
+    } catch (err) {
       setError(err.response?.data?.error || 'Failed to calculate ASTM grain size.');
     } finally {
       setIsLoading(false);


### PR DESCRIPTION
…tion` function in `frontend/src/App.js`.

A missing opening curly brace `{` on the `catch` block was introduced during a previous refactoring. This syntax error was breaking the frontend application and likely preventing the entire application from starting up correctly.

This fix restores the correct syntax, allowing the application to build and run as expected.