### PR TITLE
This commit adds guard clauses to prevent runtime errors that were ca…

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -233,6 +233,7 @@ function App() {
 
   const handleCanvasClickForEdit = (event) => {
     if (activeTool === 'delete') {
+      if (!hitCanvasRef.current) return;
       const hitCtx = hitCanvasRef.current.getContext('2d');
       const rect = event.target.getBoundingClientRect();
       const x = event.clientX - rect.left;
@@ -277,7 +278,7 @@ function App() {
       originalCtx.drawImage(img, 0, 0);
 
       const contoursToDraw = isEditing ? localContours : selectedSample?.results?.contours;
-      if (isEditing && contoursToDraw) {
+      if (isEditing && contoursToDraw && hitCanvas) {
         const hitCtx = hitCanvas.getContext('2d');
         hitCtx.clearRect(0, 0, hitCanvas.width, hitCanvas.height);
 


### PR DESCRIPTION
…using the application to crash.

The crashes occurred when functions like `handleCanvasClickForEdit` or `draw` attempted to access the `hitCanvas` reference before it was initialized, particularly when switching between application states (e.g., entering edit mode).

This fix adds checks to ensure the canvas element exists before any operations are performed on it, making the application more robust and preventing these crashes.