### PR TITLE
This commit resolves the final issue that was preventing the frontend…

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -386,7 +386,7 @@ function App() {
                     <>
                       {!isEditing && (
                         <div className="controls-bar">
-                          <Calibration sample={selectedSample} onCalibrationUpdate={handleCalibrationUpdate} originalCanvas={originalCanvasRef.current} canvasSize={canvasSize} />
+                          <Calibration sample={selectedSample} onCalibrationUpdate={handleCalibrationUpdate} originalCanvas={originalCanvasRef.current} />
                           <div className="measure-control">
                             <button onClick={handleMeasure} disabled={!selectedSample.scale_pixels_per_mm || isLoading}>
                               {isLoading ? 'Calculating...' : 'Calculate Measurements'}

--- a/frontend/src/components/Calibration.js
+++ b/frontend/src/components/Calibration.js
@@ -5,7 +5,7 @@ import './Calibration.css';
 
 const API_URL = "/api";
 
-function Calibration({ sample, onCalibrationUpdate, originalCanvas, canvasSize }) {
+function Calibration({ sample, onCalibrationUpdate, originalCanvas }) {
   const [isCalibrating, setIsCalibrating] = useState(false);
   const [points, setPoints] = useState([]);
   const [micronsPerPixel, setMicronsPerPixel] = useState('');
@@ -13,11 +13,11 @@ function Calibration({ sample, onCalibrationUpdate, originalCanvas, canvasSize }
   const overlayCanvasRef = useRef(null);
 
   useEffect(() => {
-    if (isCalibrating && canvasSize.width > 0 && canvasSize.height > 0) {
+    if (isCalibrating && originalCanvas && originalCanvas.width > 0) {
       const overlay = overlayCanvasRef.current;
       const ctx = overlay.getContext('2d');
-      overlay.width = canvasSize.width;
-      overlay.height = canvasSize.height;
+      overlay.width = originalCanvas.width;
+      overlay.height = originalCanvas.height;
       ctx.clearRect(0, 0, overlay.width, overlay.height);
 
       points.forEach(p => {


### PR DESCRIPTION
… from launching.

The root cause was a `ReferenceError` in `App.js`. A `canvasSize` state variable had been removed, but a prop with the same name was still being passed to the `<Calibration />` component. This attempt to pass an undefined variable caused the application to crash on render.

The fix involves two parts:
1.  The invalid `canvasSize` prop is removed from the `<Calibration />` invocation in `App.js`.
2.  The `Calibration.js` component is refactored to derive canvas dimensions directly from the `originalCanvas` prop it already receives, making the component more robust and self-contained.

This was the last known bug, and the application should now be stable.