### PR TITLE
This commit fixes the final critical bug that was preventing the fron…

### DIFF
--- a/frontend/src/components/Calibration.js
+++ b/frontend/src/components/Calibration.js
@@ -36,7 +36,7 @@ function Calibration({ sample, onCalibrationUpdate, originalCanvas }) {
         ctx.stroke();
       }
     }
-  }, [points, isCalibrating, originalCanvas, canvasSize]);
+  }, [points, isCalibrating, originalCanvas]);
 
   const handleCanvasClick = (event) => {
     if (!isCalibrating || points.length >= 2 || !originalCanvas) return;


### PR DESCRIPTION
…tend application from launching.

The root cause was a `ReferenceError` in `frontend/src/components/Calibration.js`. A `useEffect` hook had a dependency on a `canvasSize` variable that no longer existed as a prop, causing the application to crash instantly on render.

This commit removes the invalid reference from the `useEffect` dependency array.

This was the last in a series of bugs that have been fixed, and the application should now be fully stable and operational.