### PR TITLE
fix: Correct intercept mark drawing and abaque display

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -227,12 +227,12 @@ function App() {
       if (isHorizontal) {
         if (x >= line.startX && x <= line.endX && Math.abs(y - line.startY) < CLICK_THRESHOLD) {
           setInterceptMarks(prev => [...prev, { x, y, lineType: 'h' }]);
-          return;
+          break;
         }
       } else if (isVertical) {
         if (y >= line.startY && y <= line.endY && Math.abs(x - line.startX) < CLICK_THRESHOLD) {
           setInterceptMarks(prev => [...prev, { x, y, lineType: 'v' }]);
-          return;
+          break;
         }
       }
     }
@@ -494,9 +494,9 @@ function App() {
                         <div className="results-display">
                           <MeasurementTable measurements={selectedSample.results.measurements} onGrainHover={setHighlightedGrainId} />
                           <HistogramChart measurements={selectedSample.results.measurements} />
-                          <ASTMChart chartUrl={astmChartUrl} />
                         </div>
                       )}
+                      <ASTMChart chartUrl={astmChartUrl} />
                     </>
                   ) : (
                     <div className="placeholder"><h2>No sample selected</h2><p>Add a new sample or select one from the list.</p></div>


### PR DESCRIPTION
This commit addresses two bugs identified in user feedback:

1.  The abaque comparison chart was not being displayed after generation. This was because the `ASTMChart` component was only rendered if other measurements existed. The component has been moved out of this conditional block and will now display correctly whenever a chart URL is available.

2.  The visual marks (perpendicular bars) for the intercept method were not appearing when the user clicked on the test lines. The `handleCanvasClickForIntercept` function was modified to use `break` instead of `return` inside its loop. This ensures the event handler function always runs to completion, which is a more robust pattern within React's event system and is expected to resolve the rendering issue.