### PR TITLE
feat: Implement interactive abaque comparison viewer

### DIFF
--- a/frontend/src/components/InteractiveASTMViewer.css
+++ b/frontend/src/components/InteractiveASTMViewer.css
@@ -1,0 +1,88 @@
+.interactive-viewer-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(0, 0, 0, 0.7);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 1000;
+}
+
+.interactive-viewer-content {
+  background-color: #282c34;
+  padding: 20px;
+  border-radius: 8px;
+  width: 90%;
+  max-width: 1000px;
+  position: relative;
+  text-align: center;
+}
+
+.close-btn {
+  position: absolute;
+  top: 10px;
+  right: 15px;
+  background: none;
+  border: none;
+  color: white;
+  font-size: 24px;
+  cursor: pointer;
+}
+
+.charts-grid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 15px;
+  margin: 20px 0;
+}
+
+.chart-item {
+  border: 1px solid #444;
+  border-radius: 4px;
+  padding: 5px;
+  cursor: pointer;
+  transition: all 0.2s ease-in-out;
+}
+
+.chart-item:hover {
+  border-color: cyan;
+  transform: scale(1.05);
+}
+
+.chart-item img {
+  width: 100%;
+  height: auto;
+  display: block;
+}
+
+.chart-title {
+  margin-top: 5px;
+  font-weight: bold;
+}
+
+.navigation-controls {
+  margin-top: 20px;
+}
+
+.navigation-controls button {
+  margin: 0 10px;
+  padding: 8px 16px;
+}
+
+.loading-spinner {
+    border: 4px solid #f3f3f3;
+    border-top: 4px solid #3498db;
+    border-radius: 50%;
+    width: 40px;
+    height: 40px;
+    animation: spin 1s linear infinite;
+    margin: 20px auto;
+}
+
+@keyframes spin {
+    0% { transform: rotate(0deg); }
+    100% { transform: rotate(360deg); }
+}

--- a/frontend/src/components/InteractiveASTMViewer.js
+++ b/frontend/src/components/InteractiveASTMViewer.js
@@ -1,0 +1,77 @@
+import React, { useState, useEffect } from 'react';
+import axios from 'axios';
+import './InteractiveASTMViewer.css';
+
+const API_URL = "/api";
+
+function InteractiveASTMViewer({ sample, magnification, onSelect, onClose }) {
+  const [gValues, setGValues] = useState([1, 2, 3, 4]);
+  const [charts, setCharts] = useState({});
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    const fetchCharts = async () => {
+      if (!sample || !magnification) return;
+      setIsLoading(true);
+      setError('');
+      try {
+        const response = await axios.post(`${API_URL}/samples/${sample.id}/astm-chart`, {
+          magnification,
+          g_values: gValues,
+        });
+        setCharts(response.data);
+      } catch (err) {
+        setError(err.response?.data?.error || 'Failed to fetch ASTM charts.');
+        console.error(err);
+      } finally {
+        setIsLoading(false);
+      }
+    };
+    fetchCharts();
+  }, [sample, magnification, gValues]);
+
+  const handlePrev = () => {
+    setGValues(prev => {
+      const start = Math.max(1, prev[0] - 4);
+      return Array.from({ length: 4 }, (_, i) => start + i);
+    });
+  };
+
+  const handleNext = () => {
+    setGValues(prev => {
+        const start = prev[0] + 4;
+        if (start > 14) return prev; // Max G value
+        return Array.from({ length: 4 }, (_, i) => start + i);
+    });
+  };
+
+  return (
+    <div className="interactive-viewer-overlay">
+      <div className="interactive-viewer-content">
+        <button onClick={onClose} className="close-btn">&times;</button>
+        <h3>ASTM E112 Comparison</h3>
+        <p>Select the grain size that best matches your sample.</p>
+        {error && <p className="error-message">{error}</p>}
+        {isLoading ? (
+          <div className="loading-spinner"></div>
+        ) : (
+          <div className="charts-grid">
+            {gValues.map(g => (
+              <div key={g} className="chart-item" onClick={() => onSelect(g)}>
+                <img src={charts[g]} alt={`ASTM Grain Size G=${g}`} />
+                <div className="chart-title">G = {g}</div>
+              </div>
+            ))}
+          </div>
+        )}
+        <div className="navigation-controls">
+          <button onClick={handlePrev} disabled={gValues[0] <= 1}>Previous</button>
+          <button onClick={handleNext}>Next</button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default InteractiveASTMViewer;


### PR DESCRIPTION
This commit replaces the static ASTM E112 comparison chart with a new interactive viewer and fixes several related bugs.

Features:
- The backend can now generate individual abaque charts for specific G-values and return them as a JSON object of base64-encoded images.
- A new `InteractiveASTMViewer` component has been created on the frontend to display four charts at a time in a modal overlay.
- The viewer includes navigation buttons to load different ranges of G-value charts.
- Users can click on a chart to select it. A new backend endpoint saves the selected G-value to the sample's results.
- The "ASTM Comparison Chart" button now launches this interactive viewer.

Bug Fixes:
- Fixed a bug where many API calls were being made to an incorrect URL with a duplicated `/api` segment.
- Fixed a bug in the intercept method's click handler to prevent a single click from registering multiple times.
- The old `ASTMChart` component and its related state have been removed.