### PR TITLE
feat: Implement scaled, interactive, full-screen abaque viewer

### DIFF
--- a/frontend/src/components/AbaqueComparisonView.css
+++ b/frontend/src/components/AbaqueComparisonView.css
@@ -1,15 +1,14 @@
 .abaque-comparison-container {
     display: grid;
-    grid-template-columns: 200px 1fr 200px; /* Side columns for charts */
-    grid-template-rows: 200px 1fr 200px;
+    grid-template-columns: 250px 1fr 250px; /* Side columns for charts */
+    grid-template-rows: 250px 1fr 250px;
     gap: 10px;
     padding: 10px;
     background-color: #282c34;
     border-radius: 8px;
     border: 1px solid #444;
     width: 100%;
-    max-width: 1200px;
-    margin: auto;
+    height: 100%;
 }
 
 .abaque-main-image-wrapper {


### PR DESCRIPTION
This commit delivers a complete overhaul of the ASTM E112 abaque comparison feature, implementing a highly interactive, full-screen UI and a more scientifically accurate backend generation method based on user feedback.

The key backend change is in `generate_scaled_astm_charts`. This function now uses the sample's specific calibration (`scale_pixels_per_mm`) and image dimensions to generate Voronoi diagrams. This makes the comparison charts perfectly scaled to the user's image without requiring them to input a magnification value.

On the frontend, the `AbaqueComparisonView` component provides a new full-screen interface. It displays the sample on a central canvas, with four surrounding abaque charts. Clicking a chart overlays it on the central canvas, and a slider controls its opacity. A bug that distorted the overlay image has been fixed by preserving its aspect ratio.

The user can navigate through different G-value charts and, once satisfied with the comparison, click a "Validate" button to save the selected G-value to the sample's results.

The project version in `package.json` is updated to `0.2.0` to reflect this major feature implementation.