### PR TITLE
refactor: Revert to magnification-based charts and fix UI bugs

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -35,6 +35,7 @@ function App() {
   const [isInterceptToolActive, setIsInterceptToolActive] = useState(false);
   const [interceptMarks, setInterceptMarks] = useState([]);
   const [showASTMViewer, setShowASTMViewer] = useState(false);
+  const [viewerMagnification, setViewerMagnification] = useState(100);
 
   const originalCanvasRef = useRef(null);
   const segmentedCanvasRef = useRef(null);
@@ -172,10 +173,14 @@ function App() {
 
   const handleOpenASTMViewer = () => {
     if (!selectedSample) return;
-    if (!selectedSample.scale_pixels_per_mm) {
-      alert("Please calibrate the sample first.");
+    const magnificationStr = prompt("Enter image magnification for chart generation (e.g., 100):", "100");
+    if (!magnificationStr) return;
+    const magnification = parseFloat(magnificationStr);
+    if (isNaN(magnification) || magnification <= 0) {
+      alert("Invalid magnification.");
       return;
     }
+    setViewerMagnification(magnification);
     setShowASTMViewer(true);
   };
 
@@ -390,6 +395,13 @@ function App() {
     draw();
   }, [draw]);
 
+  useEffect(() => {
+    // Redraw the main canvas when the viewer is closed to restore the image
+    if (!showASTMViewer) {
+      draw();
+    }
+  }, [showASTMViewer, draw]);
+
   return (
     <div className="App">
       <header className="App-header"><h1>Metallographic Analysis</h1></header>
@@ -415,6 +427,7 @@ function App() {
                     {showASTMViewer ? (
                         <AbaqueComparisonView
                             sample={selectedSample}
+                            magnification={viewerMagnification}
                             onSelect={handleSelectGValue}
                             onClose={() => setShowASTMViewer(false)}
                         />

--- a/frontend/src/components/AbaqueComparisonView.css
+++ b/frontend/src/components/AbaqueComparisonView.css
@@ -1,7 +1,7 @@
 .abaque-comparison-container {
     display: grid;
     grid-template-columns: 250px 1fr 250px; /* Side columns for charts */
-    grid-template-rows: 250px 1fr 250px;
+    grid-template-rows: 1fr 2fr 1fr; /* Give more space to the central row */
     gap: 10px;
     padding: 10px;
     background-color: #282c34;

--- a/frontend/src/components/AbaqueComparisonView.js
+++ b/frontend/src/components/AbaqueComparisonView.js
@@ -4,7 +4,7 @@ import './AbaqueComparisonView.css';
 
 const API_URL = "/api";
 
-function AbaqueComparisonView({ sample, onSelect, onClose }) {
+function AbaqueComparisonView({ sample, magnification, onSelect, onClose }) {
   const [gValues, setGValues] = useState([4, 5, 6, 7]);
   const [charts, setCharts] = useState({});
   const [isLoading, setIsLoading] = useState(false);
@@ -62,11 +62,12 @@ function AbaqueComparisonView({ sample, onSelect, onClose }) {
 
   useEffect(() => {
     const fetchCharts = async () => {
-      if (!sample) return;
+      if (!sample || !magnification) return;
       setIsLoading(true);
       setError('');
       try {
         const response = await axios.post(`${API_URL}/samples/${sample.id}/astm-chart`, {
+          magnification,
           g_values: gValues,
         });
         setCharts(response.data);
@@ -78,7 +79,7 @@ function AbaqueComparisonView({ sample, onSelect, onClose }) {
       }
     };
     fetchCharts();
-  }, [sample, gValues]);
+  }, [sample, magnification, gValues]);
 
   const handlePrev = () => {
     setGValues(prev => {


### PR DESCRIPTION
This commit addresses several issues based on user feedback, including a reversal of the previous data model for chart generation.

- **Reverted Chart Generation:** The backend logic in `routes.py` has been reverted from a scale-based model to a magnification-based one as per the user's request. The function has been updated to accept the sample's dimensions to generate charts of the same size, improving comparability. The API endpoint now accepts a `magnification` value again.

- **Fixed Disappearing Image:** In `App.js`, a `useEffect` hook has been added to re-draw the main canvas when the `AbaqueComparisonView` is closed. This fixes a bug where the sample image would disappear after the comparison view was hidden.

- **Fixed Layout Overflow:** In `AbaqueComparisonView.css`, the `grid-template-rows` property has been changed to use `fr` units. This provides a more flexible distribution of space and prevents the top and bottom charts from overflowing their container.

- **Restored Magnification Prompt:** The logic to prompt for magnification has been re-implemented in `App.js` and the value is passed down to the comparison view component.