### PR TITLE
fix: Revert chart logic and fix viewer layout

### DIFF
--- a/frontend/src/components/AbaqueComparisonView.css
+++ b/frontend/src/components/AbaqueComparisonView.css
@@ -1,14 +1,15 @@
 .abaque-comparison-container {
     display: grid;
-    grid-template-columns: 250px 1fr 250px; /* Side columns for charts */
-    grid-template-rows: 1fr 2fr 1fr; /* Give more space to the central row */
+    grid-template-columns: 250px 1fr 250px;
+    grid-template-rows: auto 1fr auto; /* Let rows size to content, with center row taking up space */
     gap: 10px;
     padding: 10px;
     background-color: #282c34;
     border-radius: 8px;
     border: 1px solid #444;
     width: 100%;
-    height: 100%;
+    height: calc(100vh - 125px); /* Full viewport height minus header and some padding */
+    box-sizing: border-box;
 }
 
 .abaque-main-image-wrapper {
@@ -37,6 +38,7 @@
     flex-direction: column;
     justify-content: center;
     align-items: center;
+    overflow: hidden; /* Prevent image from spilling out */
 }
 
 .abaque-chart-item:hover {
@@ -46,8 +48,8 @@
 
 .abaque-chart-item img {
     width: 100%;
-    height: auto;
-    object-fit: cover;
+    height: 100%;
+    object-fit: contain; /* Fit without distortion */
 }
 
 .abaque-chart-item .chart-title {


### PR DESCRIPTION
This commit addresses several points of user feedback on the abaque comparison feature, including a reversal of the previous data model for chart generation and fixes for UI layout bugs.

- **Reverted Chart Generation:** The backend logic in `routes.py` has been reverted from a scale-based model to a magnification-based one as per the user's request. The function has been updated to accept the sample's dimensions to generate charts of the same size, improving comparability for the overlay feature. The API endpoint now accepts a `magnification` value again.

- **Fixed Disappearing Image:** In `App.js`, a `useEffect` hook has been added to re-draw the main canvas when the `AbaqueComparisonView` is closed. This fixes a bug where the sample image would disappear after the comparison view was hidden.

- **Fixed Layout Overflow:** In `AbaqueComparisonView.css`, the `grid-template-rows` property has been changed to better manage space, and `object-fit: contain` is used for the chart images to prevent distortion and overflow.

- **Restored Magnification Prompt:** The logic to prompt for magnification has been re-implemented in `App.js` and the value is passed down to the comparison view component.