### PR TITLE
fix: Remove invalid import from SelectProjectModal

### DIFF
--- a/frontend/src/components/SelectProjectModal.js
+++ b/frontend/src/components/SelectProjectModal.js
@@ -1,7 +1,6 @@
 import React, { useState, useEffect, useCallback } from 'react';
 import axios from 'axios';
 import './Modal.css';
-import './ProjectList.css'; // Reuse styles for the list
 
 const API_URL = '/api';
 


### PR DESCRIPTION
The `SelectProjectModal.js` component was attempting to import the `ProjectList.css` stylesheet. This file was deleted in a previous commit as part of a UI refactor, causing a compilation failure.

This commit removes the incorrect import statement, allowing the frontend to compile successfully again.